### PR TITLE
Updating rust nightly to fix docker-compose build

### DIFF
--- a/deploy/backend.Dockerfile
+++ b/deploy/backend.Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y postgresql cmake \
     && rm -rf /var/lib/apt/lists/*
 
-RUN rustup default nightly-2018-07-14
+RUN rustup default nightly-2018-10-12
 
 RUN cargo install diesel_cli --no-default-features --features postgres
 


### PR DESCRIPTION
Had a build error when using `docker-compose up` 

```sh
error: aborting due to 57 previous errors

For more information about this error, try `rustc --explain E0658`.
error: Could not compile `proc-macro2`.
warning: build failed, waiting for other jobs to finish...
error: failed to compile `diesel_cli v1.3.1`, intermediate artifacts can be found at `/tmp/cargo-installFkppN1`

Caused by:
  build failed
ERROR: Service 'backend' failed to build: The command '/bin/sh -c cargo install diesel_cli --no-default-features --features postgres' returned a non-zero code: 101
```

with a newer nightly this is resolved on my end
